### PR TITLE
Verify base branch

### DIFF
--- a/src/Drupal/Composer/DrupalInstallerPlugin.php
+++ b/src/Drupal/Composer/DrupalInstallerPlugin.php
@@ -415,7 +415,7 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
         $backupPath = $packagePath . '/' . $this->git['path'];
 
         if ($this->git['base-branch']) {
-            $this->gitBranchExists($this->git['base-branch']);
+            $this->verifyGitBranchExists($this->git['base-branch']);
 
             $newBranchName = $this->getBranchName($package);
 
@@ -493,7 +493,7 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
             return;
         }
 
-        $this->gitBranchExists($this->git['base-branch']);
+        $this->verifyGitBranchExists($this->git['base-branch']);
 
         $isGitDiff = $this->isGitDiff($branchName);
         if ($isGitDiff && (!$this->git['security'] || substr($branchName, -3) === '-SA')) {
@@ -527,9 +527,11 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
         }
     }
 
-    protected function gitBranchExists($branch_name) {
+    protected function verifyGitBranchExists($branch_name) {
         // verify the base branch exists.
-        $this->executeCommand('git rev-parse --verify %s', $this->git['base-branch']);
+        if (!$this->executeCommand('git rev-parse --verify %s', $branch_name)) {
+            throw new \Exception(sprintf('Specified base-branch "%s" does not exist', $branch_name));
+        }
     }
 
     /**

--- a/src/Drupal/Composer/DrupalInstallerPlugin.php
+++ b/src/Drupal/Composer/DrupalInstallerPlugin.php
@@ -415,6 +415,9 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
         $backupPath = $packagePath . '/' . $this->git['path'];
 
         if ($this->git['base-branch']) {
+            // verify the base branch exists.
+            $this->executeCommand('git rev-parse --verify %s', $this->git['base-branch']);
+
             $newBranchName = $this->getBranchName($package);
 
             $this->io->write("  - Creating branch <info>$newBranchName</info> in GIT.");

--- a/src/Drupal/Composer/DrupalInstallerPlugin.php
+++ b/src/Drupal/Composer/DrupalInstallerPlugin.php
@@ -415,8 +415,7 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
         $backupPath = $packagePath . '/' . $this->git['path'];
 
         if ($this->git['base-branch']) {
-            // verify the base branch exists.
-            $this->executeCommand('git rev-parse --verify %s', $this->git['base-branch']);
+            $this->gitBranchExists($this->git['base-branch']);
 
             $newBranchName = $this->getBranchName($package);
 
@@ -494,6 +493,8 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
             return;
         }
 
+        $this->gitBranchExists($this->git['base-branch']);
+
         $isGitDiff = $this->isGitDiff($branchName);
         if ($isGitDiff && (!$this->git['security'] || substr($branchName, -3) === '-SA')) {
             if ($this->io->isVeryVerbose()) {
@@ -524,6 +525,11 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
                 $this->afterAllPatchesGitBranchCleanup($package);
             }
         }
+    }
+
+    protected function gitBranchExists($branch_name) {
+        // verify the base branch exists.
+        $this->executeCommand('git rev-parse --verify %s', $this->git['base-branch']);
     }
 
     /**


### PR DESCRIPTION
When setting a site up to use this, I used the 'base-branch' setting but the base branch didn't exist. There were no errors (unless verbose is used) and the installation still runs. So what ends up happening is all the patches get committed to the branch you started on instead, and **pushed**!

This adds a new `verifyGitBranchExists` method we can use, this enforces the branch exists by throwing an exception if it doesn't.
