### PR TITLE
Fix .info files with version but missing other packager fields.

### DIFF
--- a/src/Drupal/Composer/DrupalInstallerPlugin.php
+++ b/src/Drupal/Composer/DrupalInstallerPlugin.php
@@ -407,7 +407,8 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
 
     protected function rewriteFileInfo($packageName, $filePath, $info) {
         $version = $this->getFileVersionInfo($filePath);
-        if (!$version) {
+        $old_info = $this->getFileDrupalInfo($filePath);
+        if (!$version || (isset($info['project']) && !isset($old_info['project'])) || (isset($info['datestamp']) && !isset($old_info['datestamp']))) {
             if (strpos($info['version'], 'dev') === FALSE && isset($this->info[$packageName][$filePath]['version']) && $this->info[$packageName][$filePath]['version'] === $info['version']) {
                 $info = $this->info[$packageName][$filePath] + $info;
             }


### PR DESCRIPTION
Some .info files define a version without defining the other packaging fields, despite best practices. Edit the .info file if *any* of the packaging fields are missing in comparison to the computed info, not just version.

Noticed this when I was checking for updates and saw that file_entity was not showing on the update status page.