### PR TITLE
Update Drupal Composer installer to work with Drupal 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Drupal composer installer plugin
 
 * Installs Drupal core into drupal-root.
 * Installs Drupal modules, themes, and libraries into the sites or profile directory.
-* For example, installs Drupal modules into {drupal-root}/sites/all/modules/{dir}.
-* For example, installs Drupal themes into {drupal-root}/sites/all/themes/{dir}.
-* For example, installs libraries into {drupal-root}/sites/all/libraries.
+* For example, installs Drupal modules into {drupal-root}/modules/{dir}.
+* For example, installs Drupal themes into {drupal-root}/themes/{dir}.
+* For example, installs libraries into {drupal-root}/libraries.
 * Saves and restores custom code around drupal/drupal installation.
 
 ## Usage
@@ -25,13 +25,13 @@ To use this installer in your project build, in your composer.json add
   }
 ```
 
-You'll also want to add a packageist as follows (that is, until drupal.org implements it's own):
+You'll also want to add the Drupal packages repository as follows:
 
 ```
   "repositories": [
     {
       "type": "composer",
-      "url": "https://packagist.drupal-composer.org/"
+      "url": "https://packages.drupal.org/8"
     }
   ]
 ```
@@ -44,7 +44,7 @@ Your somewhat complete composer.json might look like:
   "repositories": [
     {
       "type": "composer",
-      "url": "https://packagist.drupal-composer.org/"
+      "url": "https://packages.drupal.org/8"
     },
     {
       "type": "git",
@@ -64,7 +64,7 @@ Your somewhat complete composer.json might look like:
 
 ## Options
 
-### drupal-root - the directory to install drupal into, defaults to 'core'
+### drupal-root - the directory to install drupal into, defaults to 'web'
 
 ```
   "extra": {
@@ -72,7 +72,7 @@ Your somewhat complete composer.json might look like:
   }
 ```
 
-### drupal-site - the directory under 'sites', defaults to 'all'.
+### drupal-site - the directory under 'sites', only used if 'drupal-sites' is set, defaults to 'all'.
 
 ```
   "extra": {
@@ -82,7 +82,7 @@ Your somewhat complete composer.json might look like:
 
 When set, changes the install from sites/all to sites/mysite.
 
-### drupal-sites - the directory under drupal-root, defaults to 'sites'.
+### drupal-sites - the directory under drupal-root, empty by default (installs into global modules/ and themes/ folders).
 
 When installing a profile, set this to 'profiles'.
 
@@ -93,9 +93,9 @@ When installing a profile, set this to 'profiles'.
   }
 ```
 
-### drupal-libraries - map of packages to install into {drupal-root}/sites/all/libraries.
+### drupal-libraries - map of packages to install into {drupal-root}/libraries.
 
-The package is the key name. Any value specifies a directory name under sites/all/libraries.
+The package is the key name. Any value specifies a directory name under libraries/.
 
 ```
   "extra": {
@@ -110,8 +110,8 @@ The value ```ckeditor/ckeditor``` is implied by default.
 
 ### drupal-modules - map of packages to directories.
 
-* drupal/* : contrib, by default all drupal modules are installed in {drupal-root}/sites/all/modules/contrib
-or {drupal-root}/sites/all/modules/project. Additional directories can be specified.
+* drupal/* : contrib, by default all drupal modules are installed in {drupal-root}/modules/contrib
+or {drupal-root}/modules/project. Additional directories can be specified.
 
 ```
   "extra": {
@@ -131,7 +131,7 @@ This is array of custom code paths that should be saved before drupal/drupal is 
 ```
   "extra": {
     "drupal-custom": [
-      "core/sites/all/themes/mytheme"
+      "core/themes/mytheme"
     ]
   }
 ```

--- a/src/Drupal/Composer/DrupalInstaller.php
+++ b/src/Drupal/Composer/DrupalInstaller.php
@@ -26,8 +26,8 @@ class DrupalInstaller extends LibraryInstaller {
         'drupal-libraries' => array(),
         'drupal-modules' => array(),
         'drupal-themes' => array(),
-        'drupal-root' => 'core',
-        'drupal-sites' => 'sites',
+        'drupal-root' => 'web',
+        'drupal-sites' => '',
         'drupal-site' => 'all',
     );
 
@@ -86,10 +86,22 @@ class DrupalInstaller extends LibraryInstaller {
         if ($packageName === 'drupal/drupal') {
             $path = $this->options['drupal-root'];
         }
+        elseif ($packageName === 'drupal/core') {
+            $path = $this->options['drupal-root'] . '/core';
+            if (!is_dir($path)) {
+                mkdir($path);
+            }
+        }
         else {
             list($vendor, $name) = explode('/', $packageName);
 
-            $basePath = $this->options['drupal-root'] . '/' . $this->options['drupal-sites'] . '/' . $this->options['drupal-site'];
+            if (empty($this->options['drupal-sites'])) {
+                $basePath = $this->options['drupal-root'];
+            }
+            else {
+                $basePath = $this->options['drupal-root'] . '/' . $this->options['drupal-sites'] . '/' . $this->options['drupal-site'];
+            }
+
             $path = '';
             foreach (array('module' => 'drupal-modules', 'theme' => 'drupal-themes') as $type => $drupalType) {
                 if ($package->getType() === "drupal-$type") {

--- a/src/Drupal/Composer/DrupalInstallerPlugin.php
+++ b/src/Drupal/Composer/DrupalInstallerPlugin.php
@@ -58,6 +58,20 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
     protected $patches;
 
     /**
+     * Webroot folder.
+     *
+     * @var string
+     */
+    protected $drupalRoot;
+
+    /**
+     * List of custom path that should be perserved over installs.
+     *
+     * @var string[]
+     */
+    protected $drupalCustom;
+
+    /**
      * {@inheritdoc}
      */
     public function activate(Composer $composer, IOInterface $io) {
@@ -76,7 +90,7 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
         $extra = $this->composer->getPackage()->getExtra();
         $extra += array(
             'drupal-custom' => array(),
-            'drupal-root' => 'core',
+            'drupal-root' => 'web',
             'patches' => array(),
         );
 
@@ -262,7 +276,7 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
             if (is_dir($filePath)) {
                 $this->readDirVersionInfo($packageName, $filePath);
             }
-            elseif (substr($partialPath, -5) === '.info') {
+            elseif (substr($partialPath, -9) === '.info.yml') {
                 $this->info[$packageName][$filePath] = $this->getFileDrupalInfo($filePath);
             }
         }
@@ -273,7 +287,7 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
         $contents = @file($filePath);
         if ($contents) {
             foreach ($contents as $line) {
-              if (preg_match('/^\s*(\w+)\s*=\s*"?([^"\n]*)"?/', $line, $matches)) {
+              if (preg_match('/^\s*(\w+)\s*:\s*"?([^"\n]*)"?/', $line, $matches)) {
                   $key = $matches[1];
                   $value = $matches[2];
                   $info[$key] = $value;
@@ -288,7 +302,7 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
 
     protected function getFileVersionInfo($filePath) {
         $contents = @file_get_contents($filePath);
-        $regex = '/\s+version\s*=\s*"?([^"\s]*)"?/';
+        $regex = '/\s+version\s*:\s*"?([^"\s]*)"?/';
         if ($contents && preg_match_all($regex, $contents, $matches)) {
             $version = end($matches[1]);
             return $this->normalizeVersion($version);
@@ -399,7 +413,7 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
             if (is_dir($filePath)) {
                 $this->rewriteDirInfo($packageName, $filePath, $info);
             }
-            elseif (substr($partialPath, -5) === '.info') {
+            elseif (substr($partialPath, -9) === '.info.yml') {
                 $this->rewriteFileInfo($packageName, $filePath, $info);
             }
         }
@@ -415,13 +429,13 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
             $this->io->write("  - Rewriting <info>$filePath</info> with version <info>$info[version]</info>");
 
             $moreInfo = "\n"
-                . "; Information added by drupal-composer-installer packaging script on $info[date]\n"
-                . "version = \"$info[version]\"\n";
+                . "# Information added by drupal-composer-installer packaging script on $info[date]\n"
+                . "version: \"$info[version]\"\n";
             if (isset($info['project'])) {
-                $moreInfo .= "project = \"$info[project]\"\n";
+                $moreInfo .= "project: \"$info[project]\"\n";
               }
             if (isset($info['datestamp'])) {
-                $moreInfo .= "datestamp = \"$info[datestamp]\"\n";
+                $moreInfo .= "datestamp: \"$info[datestamp]\"\n";
               }
             file_put_contents($filePath, $moreInfo, FILE_APPEND);
         }


### PR DESCRIPTION
I updated the script to work with Drupal 8 sites. I am not sure wether to make the Drupal versoion configurable or simply create a new branch for 8.

"drupal-site" and "drupal-sites" configuration attribues are a bit strangely named - specially after this change where we start supporting global `themes/` and `modules/` folders as installation destinations. I am wondering if we should change how they are named?