### PR TITLE
Prevent crash when host is not a URI.

### DIFF
--- a/src/Drupal/Composer/DrupalInstallerPlugin.php
+++ b/src/Drupal/Composer/DrupalInstallerPlugin.php
@@ -614,7 +614,7 @@ class DrupalInstallerPlugin implements PluginInterface, EventSubscriberInterface
             if (isset($repo_config['url'])) {
                 // The new packages.drupal.org separates the platform from the version entirely.
                 $repourl = parse_url($repo_config['url']);
-                if ($repourl['host'] == 'packages.drupal.org') {
+                if (isset($repourl['host']) && $repourl['host'] == 'packages.drupal.org') {
                     $platform = substr($repourl['path'], 1);
                 }
             }


### PR DESCRIPTION
If the 'url' is in the legit format of name@host, the plugin crashes with an undefined index: host.

Since that case doesn't matter here, a simple isset() check fixes the problem.